### PR TITLE
Fix podspec name for ios

### DIFF
--- a/HugotomaziCapacitorNavigationBar.podspec
+++ b/HugotomaziCapacitorNavigationBar.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'NavigationBar'
+  s.name = 'HugotomaziCapacitorNavigationBar'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']


### PR DESCRIPTION
Running `npx cap sync` leads to the error

```
[!] No podspec found for `HugotomaziCapacitorNavigationBar` in
        `../../node_modules/@hugotomazi/capacitor-navigation-bar`
```

It seems like the name in the App/Podfile is generated from the packages (?).

This PR renames the podspec name accordingly.