### PR TITLE
fix: KeyboardWillShow and KeyboardDidShow events not firing up when using a transparent navbar

### DIFF
--- a/android/src/main/java/br/com/tombus/capacitor/plugin/navigationbar/NavigationBarPlugin.java
+++ b/android/src/main/java/br/com/tombus/capacitor/plugin/navigationbar/NavigationBarPlugin.java
@@ -7,6 +7,8 @@ import android.app.Activity;
 import android.view.Window;
 import android.view.WindowManager;
 
+import androidx.core.view.WindowCompat;
+
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -76,7 +78,13 @@ public class NavigationBarPlugin extends Plugin {
                     Boolean isTransparent = call.getBoolean("isTransparent");
                     Window window = getActivity().getWindow();
                     if(isTransparent) {
-                        window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                            WindowCompat.setDecorFitsSystemWindows(window, false);
+                            window.setNavigationBarColor(Color.TRANSPARENT);
+                            window.setNavigationBarContrastEnforced(false);
+                        } else {
+                            window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+                        }
                     } else {
                         window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
                     }


### PR DESCRIPTION
This fixes keyboard events not firing up when using the transparent navbar

*not compatible with the resizeOnFullScreen keyboard plugin option