### PR TITLE
fix: keep the navbar hidden on user tap

### DIFF
--- a/android/src/main/java/br/com/tombus/capacitor/plugin/navigationbar/NavigationBarPlugin.java
+++ b/android/src/main/java/br/com/tombus/capacitor/plugin/navigationbar/NavigationBarPlugin.java
@@ -29,6 +29,11 @@ public class NavigationBarPlugin extends Plugin {
             WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
             windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.navigationBars());
 
+            // keep the navbar hidden when tapping/swiping the screen
+            windowInsetsControllerCompat.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
+
             window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             notifyListeners("onHide", new JSObject());
             call.resolve();


### PR DESCRIPTION
this keep the navbar hidden even if the user taps  or swipes in the screen.

If this is not the default wanted behaviour I can wrap this with a flag.

Thanks 